### PR TITLE
Add investor pitch deck PDF

### DIFF
--- a/INVESTOR_PITCH.pdf
+++ b/INVESTOR_PITCH.pdf
@@ -1,0 +1,106 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [4 0 R 6 0 R 8 0 R 10 0 R 12 0 R] /Count 5 >>
+endobj
+3 0 obj
+<< /Length 62 >>
+stream
+BT
+/F1 18 Tf
+1 0 0 1 72 740 Tm (proClaim Investor Pitch) Tj
+ET
+endstream
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 3 0 R /Resources << /Font << /F1 3 0 R >> >> >>
+endobj
+5 0 obj
+<< /Length 239 >>
+stream
+BT
+/F1 18 Tf
+1 0 0 1 72 740 Tm (Project Overview:) Tj
+1 0 0 1 72 716 Tm (- Next.js 14 app with tRPC and Prisma) Tj
+1 0 0 1 72 692 Tm (- Blockchain utilities in packages/proclaim) Tj
+1 0 0 1 72 668 Tm (- Cron jobs sync on-chain state) Tj
+ET
+endstream
+endobj
+6 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 5 0 R /Resources << /Font << /F1 3 0 R >> >> >>
+endobj
+7 0 obj
+<< /Length 264 >>
+stream
+BT
+/F1 18 Tf
+1 0 0 1 72 740 Tm (Updated Investor Plan:) Tj
+1 0 0 1 72 716 Tm (1. Switch to a dedicated backend service) Tj
+1 0 0 1 72 692 Tm (2. Redesign and audit blockchain contracts) Tj
+1 0 0 1 72 668 Tm (3. Harden infrastructure and run end-to-end tests) Tj
+ET
+endstream
+endobj
+8 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 7 0 R /Resources << /Font << /F1 3 0 R >> >> >>
+endobj
+9 0 obj
+<< /Length 323 >>
+stream
+BT
+/F1 18 Tf
+1 0 0 1 72 740 Tm (Team & Timeline:) Tj
+1 0 0 1 72 716 Tm (- Lead engineer/architect) Tj
+1 0 0 1 72 692 Tm (- Backend engineers \(2\)) Tj
+1 0 0 1 72 668 Tm (- Frontend developer) Tj
+1 0 0 1 72 644 Tm (- Blockchain engineer) Tj
+1 0 0 1 72 620 Tm (- DevOps and QA) Tj
+1 0 0 1 72 596 Tm (- 6-8 month effort) Tj
+ET
+endstream
+endobj
+10 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 9 0 R /Resources << /Font << /F1 3 0 R >> >> >>
+endobj
+11 0 obj
+<< /Length 252 >>
+stream
+BT
+/F1 18 Tf
+1 0 0 1 72 740 Tm (Cost Estimate \(Warsaw\):) Tj
+1 0 0 1 72 716 Tm (- Average 25-30k PLN per person per month) Tj
+1 0 0 1 72 692 Tm (- 7-8 people for eight months) Tj
+1 0 0 1 72 668 Tm (- Approximately 1.6-1.9M PLN \(400k-470k USD\)) Tj
+ET
+endstream
+endobj
+12 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 11 0 R /Resources << /Font << /F1 3 0 R >> >> >>
+endobj
+13 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 14
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000141 00000 n 
+0000000253 00000 n 
+0000000379 00000 n 
+0000000669 00000 n 
+0000000795 00000 n 
+0000001110 00000 n 
+0000001236 00000 n 
+0000001610 00000 n 
+0000001737 00000 n 
+0000002041 00000 n 
+0000002169 00000 n 
+trailer
+<< /Root 1 0 R /Size 14 >>
+startxref
+2240
+%%EOF

--- a/scripts/generate_pitch_pdf.py
+++ b/scripts/generate_pitch_pdf.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from textwrap import dedent
+
+# Simple PDF generator without external dependencies
+# Generates a PDF pitch deck for the proClaim project
+
+def escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+def make_pdf(pages, out_path="INVESTOR_PITCH.pdf"):
+    header = "%PDF-1.4\n"
+    objects = []
+    kids = []
+    obj_num = 1
+
+    def add(obj_str):
+        nonlocal obj_num
+        objects.append((obj_num, obj_str))
+        obj_num += 1
+        return obj_num - 1
+
+    # Catalog placeholder (object 1)
+    add("<< /Type /Catalog /Pages 2 0 R >>")
+    # Pages object will be object 2
+    pages_obj_num = add("")  # placeholder, to be replaced later
+
+    content_obj_nums = []
+    page_obj_nums = []
+
+    for page_text in pages:
+        lines = page_text.strip().split("\n")
+        stream_lines = ["BT", "/F1 18 Tf"]
+        y = 740
+        for line in lines:
+            stream_lines.append(f"1 0 0 1 72 {y} Tm ({escape(line)}) Tj")
+            y -= 24
+        stream_lines.append("ET")
+        content = "\n".join(stream_lines)
+        content_obj = f"<< /Length {len(content)} >>\nstream\n{content}\nendstream"
+        cnum = add(content_obj)
+        content_obj_nums.append(cnum)
+        page_obj = f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents {cnum} 0 R /Resources << /Font << /F1 3 0 R >> >> >>"
+        pnum = add(page_obj)
+        page_obj_nums.append(pnum)
+        kids.append(f"{pnum} 0 R")
+
+    # Font object (object after pages and contents)
+    add("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    # Update pages object with kids
+    pages_obj_idx = 1  # second object
+    kids_str = "[" + " ".join(kids) + "]"
+    pages_obj = f"<< /Type /Pages /Kids {kids_str} /Count {len(kids)} >>"
+    objects[pages_obj_idx] = (2, pages_obj)
+
+    # Build PDF body and calculate offsets
+    pdf = header
+    offsets = []
+    for num, obj in objects:
+        offsets.append(len(pdf))
+        pdf += f"{num} 0 obj\n{obj}\nendobj\n"
+
+    startxref = len(pdf)
+    xref = f"xref\n0 {len(objects)+1}\n0000000000 65535 f \n"
+    for off in offsets:
+        xref += f"{off:010} 00000 n \n"
+    trailer = f"trailer\n<< /Root 1 0 R /Size {len(objects)+1} >>\nstartxref\n{startxref}\n%%EOF"
+    pdf += xref + trailer
+
+    with open(out_path, "wb") as f:
+        f.write(pdf.encode("latin1"))
+
+if __name__ == "__main__":
+    pages = [
+        "proClaim Investor Pitch",
+        dedent(
+            """
+            Project Overview:
+            - Next.js 14 app with tRPC and Prisma
+            - Blockchain utilities in packages/proclaim
+            - Cron jobs sync on-chain state
+            """
+        ).strip(),
+        dedent(
+            """
+            Updated Investor Plan:
+            1. Switch to a dedicated backend service
+            2. Redesign and audit blockchain contracts
+            3. Harden infrastructure and run end-to-end tests
+            """
+        ).strip(),
+        dedent(
+            """
+            Team & Timeline:
+            - Lead engineer/architect
+            - Backend engineers (2)
+            - Frontend developer
+            - Blockchain engineer
+            - DevOps and QA
+            - 6-8 month effort
+            """
+        ).strip(),
+        dedent(
+            """
+            Cost Estimate (Warsaw):
+            - Average 25-30k PLN per person per month
+            - 7-8 people for eight months
+            - Approximately 1.6-1.9M PLN (400k-470k USD)
+            """
+        ).strip(),
+    ]
+    make_pdf(pages)


### PR DESCRIPTION
## Summary
- script to generate a minimal PDF pitch deck
- produced `INVESTOR_PITCH.pdf` with project overview and investor plan

## Testing
- `pnpm lint` *(fails: `dotenv` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406a13ef9883218b415adda3ca7be6